### PR TITLE
Add bottom-margin: don't cling to next element

### DIFF
--- a/style.less
+++ b/style.less
@@ -1,0 +1,5 @@
+div.addnewpage {
+    select, input {
+        margin-right: 3px;
+    }
+}

--- a/syntax.php
+++ b/syntax.php
@@ -97,7 +97,7 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
 
             $newpagetemplateinput = $this->_htmlTemplateInput($data['newpagetemplates']);
 
-            $form = '<div class="addnewpage">' . DOKU_LF
+            $form = '<div class="addnewpage"><p>' . DOKU_LF
                 . DOKU_TAB . '<form name="addnewpage" method="get" action="' . DOKU_BASE . DOKU_SCRIPT . '" accept-charset="' . $lang['encoding'] . '">' . DOKU_LF
                 . DOKU_TAB . DOKU_TAB . $namespaceinput . DOKU_LF
                 . DOKU_TAB . DOKU_TAB . '<input class="edit" type="text" name="title" size="20" maxlength="255" tabindex="2" />' . DOKU_LF
@@ -106,7 +106,7 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
                 . DOKU_TAB . DOKU_TAB . '<input type="hidden" name="id" />' . DOKU_LF
                 . DOKU_TAB . DOKU_TAB . '<input class="button" type="submit" value="' . $this->getLang('okbutton') . '" tabindex="4" />' . DOKU_LF
                 . DOKU_TAB . '</form>' . DOKU_LF
-                . '</div>';
+                . '</p></div>';
             $renderer->doc .= $form;
 
             return true;

--- a/syntax.php
+++ b/syntax.php
@@ -97,16 +97,17 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
 
             $newpagetemplateinput = $this->_htmlTemplateInput($data['newpagetemplates']);
 
-            $form = '<div class="addnewpage"><p>' . DOKU_LF
-                . DOKU_TAB . '<form name="addnewpage" method="get" action="' . DOKU_BASE . DOKU_SCRIPT . '" accept-charset="' . $lang['encoding'] . '">' . DOKU_LF
-                . DOKU_TAB . DOKU_TAB . $namespaceinput . DOKU_LF
-                . DOKU_TAB . DOKU_TAB . '<input class="edit" type="text" name="title" size="20" maxlength="255" tabindex="2" />' . DOKU_LF
+            $form = '<div class="addnewpage"><p>'
+                . '<form name="addnewpage" method="get" action="' . DOKU_BASE . DOKU_SCRIPT . '" accept-charset="' . $lang['encoding'] . '">'
+                . $namespaceinput
+                . '<input class="edit" type="text" name="title" size="20" maxlength="255" tabindex="2" />'
                 . $newpagetemplateinput
-                . DOKU_TAB . DOKU_TAB . '<input type="hidden" name="do" value="edit" />' . DOKU_LF
-                . DOKU_TAB . DOKU_TAB . '<input type="hidden" name="id" />' . DOKU_LF
-                . DOKU_TAB . DOKU_TAB . '<input class="button" type="submit" value="' . $this->getLang('okbutton') . '" tabindex="4" />' . DOKU_LF
-                . DOKU_TAB . '</form>' . DOKU_LF
+                . '<input type="hidden" name="do" value="edit" />'
+                . '<input type="hidden" name="id" />'
+                . '<input class="button" type="submit" value="' . $this->getLang('okbutton') . '" tabindex="4" />'
+                . '</form>'
                 . '</p></div>';
+
             $renderer->doc .= $form;
 
             return true;


### PR DESCRIPTION
Wrapped it in a `<p>` tag to ensure the appropriate bottom-margins to avoid the impression that the from "clings" the next headline/element.

Also cleaned the html source a bit. At some point this manual form generation should probably be replaced with DokuWikis new Form system: https://www.dokuwiki.org/devel:form
