### PR TITLE
trim namespace suffix

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,4 @@ $conf['addpage_exclude']  = "wiki;playground";
 $conf['addpage_showroot'] = 1;
 $conf['addpage_hide']     = 1;
 $conf['addpage_hideACL']  = 0;
+$conf['addpage_trimSuffix'] = "";

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,3 +3,4 @@ $meta['addpage_exclude']  = array('string');
 $meta['addpage_showroot'] = array('onoff');
 $meta['addpage_hide']     = array('onoff');
 $meta['addpage_hideACL']  = array('onoff');
+$meta['addpage_trimSuffix']  = array('string');

--- a/lang/de-informal/settings.php
+++ b/lang/de-informal/settings.php
@@ -9,3 +9,4 @@ $lang['addpage_exclude']       = 'Namespaces ausschließen (getrennt mit ; )';
 $lang['addpage_showroot']      = 'Wurzel-Namespace anzeigen';
 $lang['addpage_hide']          = '{{NEWPAGE>[ns]}} Syntax: Ausgewählt, diese Namespace-Selektion verbergen. Nicht ausgewählt, nur diese Namespace-Selektion anzeigen.';
 $lang['addpage_hideACL']       = 'Wenn ein Benutzer keine Berechtigung hat: Ausgewählt, Anzeige wird verborgen. Nicht ausgewählt, Es wird eine Fehlermeldung ausgegeben.';
+$lang['addpage_trimSuffix']    = 'Diesen String aus dem Namespace-Suffix entfernen';

--- a/lang/de/settings.php
+++ b/lang/de/settings.php
@@ -8,3 +8,4 @@ $lang['addpage_exclude']       = 'Namespaces ausschließen (getrennt mit ; )';
 $lang['addpage_showroot']      = 'Wurzel-Namespace anzeigen';
 $lang['addpage_hide']          = '{{NEWPAGE>[ns]}} Syntax: Ausgewählt, diese Namespace-Selektion verbergen. Nicht ausgewählt, nur diese Namespace-Selektion anzeigen.';
 $lang['addpage_hideACL']       = 'Wenn ein Benutzer keine Berechtigung hat: Ausgewählt, Anzeige wird verborgen. Nicht ausgewählt, Es wird eine Fehlermeldung ausgegeben.';
+$lang['addpage_trimSuffix']    = 'Diesen String aus dem Namespace-Suffix entfernen';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,3 +8,4 @@ $lang['addpage_exclude']  = "Excluded namespaces (separated with ;)";
 $lang['addpage_showroot'] = "Show root namespace";
 $lang['addpage_hide']     = "When you use {{NEWPAGE>[ns]}} syntax: Hide namespace selection (unchecked: show only subnamespaces)";
 $lang['addpage_hideACL']  = "Hide {{NEWPAGE}} if user does not have rights to add pages (show message if unchecked)";
+$lang['addpage_trimSuffix'] = "Trim suffix from namespace";

--- a/syntax.php
+++ b/syntax.php
@@ -123,12 +123,21 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
     protected function _parseNS($ns) {
         global $ID;
         if(strpos($ns, '@PAGE@') !== false) {
-            return cleanID(str_replace('@PAGE@', $ID, $ns));
+          $ns = cleanID(str_replace('@PAGE@', $ID, $ns));
+        } elseif($ns == "@NS@") {
+          $ns = getNS($ID);
+        } else {
+          $ns = preg_replace("/^\.(:|$)/", dirname(str_replace(':', '/', $ID)) . "$1", $ns);
+          $ns = str_replace("/", ":", $ns);
+          $ns = cleanID($ns);
         }
-        if($ns == "@NS@") return getNS($ID);
-        $ns = preg_replace("/^\.(:|$)/", dirname(str_replace(':', '/', $ID)) . "$1", $ns);
-        $ns = str_replace("/", ":", $ns);
-        $ns = cleanID($ns);
+        $trimSuffix = trim($this->getConf('addpage_trimSuffix'));
+        if (strlen($trimSuffix) > 0) {
+          if (substr(strtolower($ns), -1-strlen($trimSuffix)) == strtolower(":".$trimSuffix))
+            $ns = substr($ns, 0, -1-strlen($trimSuffix));
+          if (substr(strtolower($ns), -2-strlen($trimSuffix)) == strtolower(":".$trimSuffix).":")
+            $ns = substr($ns, 0, -1-strlen($trimSuffix));
+        }
         return $ns;
     }
 


### PR DESCRIPTION
When using the plugin on a page with name suffix ":start", I want it to trim ":start" from @PAGE@ automatically.