### PR TITLE
Add alternative syntax to add entire namespace

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,7 +20,11 @@ jQuery(document).ready(function() {
         var ns = jQuery(this).find("[name='np_cat']");
         var title = jQuery(this).find("input[name='title']");
         var id = ns.val()+":"+title.val();
-        jQuery(this).find("input[name='id']").val(id);
+        var $idInput =  jQuery(this).find("input[name='id']");
+        if ($idInput.data('forcens')) {
+            id += ':';
+        }
+        $idInput.val(id);
 
         // Clean up the form vars, just to make the resultant URL a bit nicer
         ns.prop("disabled", true);

--- a/syntax.php
+++ b/syntax.php
@@ -38,6 +38,7 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
      */
     public function connectTo($mode) {
         $this->Lexer->addSpecialPattern('\{\{NEWPAGE[^\}]*\}\}', $mode, 'plugin_addnewpage');
+        $this->Lexer->addSpecialPattern('\{\{NEWNS[^\}]*\}\}', $mode, 'plugin_addnewpage');
     }
 
     /**
@@ -59,7 +60,14 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
      */
     public function handle($match, $state, $pos, Doku_Handler $handler) {
         /* @codingStandardsIgnoreEnd */
-        $options = substr($match, 9, -2); // strip markup
+        if (substr($match, 2, 5) === 'NEWNS') {
+            $createNamespace = true;
+            $optionsStart = 7;
+        } else {
+            $createNamespace = false;
+            $optionsStart = 9;
+        }
+        $options = substr($match, $optionsStart, -2); // strip markup
         $options = explode('#', $options, 2);
 
         $namespace = trim(ltrim($options[0], '>'));
@@ -67,7 +75,8 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
         $templates = array_map('trim', $templates);
         return array(
             'namespace' => $namespace,
-            'newpagetemplates' => $templates
+            'newpagetemplates' => $templates,
+            'createNamespace' => $createNamespace,
         );
     }
 
@@ -103,7 +112,7 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
                 . DOKU_TAB . DOKU_TAB . '<input class="edit" type="text" name="title" size="20" maxlength="255" tabindex="2" />' . DOKU_LF
                 . $newpagetemplateinput
                 . DOKU_TAB . DOKU_TAB . '<input type="hidden" name="do" value="edit" />' . DOKU_LF
-                . DOKU_TAB . DOKU_TAB . '<input type="hidden" name="id" />' . DOKU_LF
+                . DOKU_TAB . DOKU_TAB . '<input type="hidden" name="id" data-forcens="'.$data['createNamespace'].'" />' . DOKU_LF
                 . DOKU_TAB . DOKU_TAB . '<input class="button" type="submit" value="' . $this->getLang('okbutton') . '" tabindex="4" />' . DOKU_LF
                 . DOKU_TAB . '</form>' . DOKU_LF
                 . '</div>';


### PR DESCRIPTION
The are scenarios where it is desirable to enforce the creation of a new namespace instead of only creating a new page.

This adds the alternative Syntax `{{NEWNS}}` which effectively only appends an `:` to the id. All templates, options, etc. can still be used just the same.

Please let me know what you think and if you'd like any adjustments.