### PR TITLE
Always use id of main page in replacements

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -121,12 +121,13 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
      * @author Michael Braun <michael-dev@fami-braun.de>
      */
     protected function _parseNS($ns) {
-        global $ID;
+        global $INFO;
+        $id = $INFO['id'];
         if(strpos($ns, '@PAGE@') !== false) {
-            return cleanID(str_replace('@PAGE@', $ID, $ns));
+            return cleanID(str_replace('@PAGE@', $id, $ns));
         }
-        if($ns == "@NS@") return getNS($ID);
-        $ns = preg_replace("/^\.(:|$)/", dirname(str_replace(':', '/', $ID)) . "$1", $ns);
+        if($ns == "@NS@") return getNS($id);
+        $ns = preg_replace("/^\.(:|$)/", dirname(str_replace(':', '/', $id)) . "$1", $ns);
         $ns = str_replace("/", ":", $ns);
         $ns = cleanID($ns);
         return $ns;


### PR DESCRIPTION
If we use the `@PAGE@` and `@NS@` substitutions in a `{{NEWPAGE>}}` form in the sidebar or similar pages, then we still want `@PAGE@` to evaluate to the page we are currently viewing and not to the sidebar.