### PR TITLE
addnewpage with @NS@ in sidebar

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -121,7 +121,7 @@ class syntax_plugin_addnewpage extends DokuWiki_Syntax_Plugin {
      * @author Michael Braun <michael-dev@fami-braun.de>
      */
     protected function _parseNS($ns) {
-        global $ID;
+        $ID=getID();
         if(strpos($ns, '@PAGE@') !== false) {
             return cleanID(str_replace('@PAGE@', $ID, $ns));
         }


### PR DESCRIPTION
If you use addnewpage with @NS@ in the sidebar, you get the namespace of the sidebar page (global $ID) and not the viewed one.