### PR TITLE
Only append page title if not empty

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,8 +27,8 @@ jQuery(function () {
             if (page_id.indexOf(PLACEHOLDER) !== -1) {
                 // Process the placeholder
                 page_id = page_id.replaceAll(PLACEHOLDER, $title.val());
-            } else {
-                // There is no placeholder, just append the user's input
+            } else if ($title.val()) {
+                // There is no placeholder, just append the user's input (if any)
                 page_id += ":" + $title.val();
             }
 


### PR DESCRIPTION
This fixes a regression introduced by fix for #110 (commit 2184b9df536ba26b3fce095eb7dbfd3499ee4eda), which prevented creation of a new page when using the `autopage` option (the addnewpage form was appending a `:` to the name, causing DokuWiki to create a "start" page in a new namespace instead.

Fixes #118