### PR TITLE
Allow disabling creation of subnamespaces

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -4,4 +4,4 @@ $conf['addpage_showroot'] = 1;
 $conf['addpage_hide']     = 1;
 $conf['addpage_hideACL']  = 0;
 $conf['addpage_autopage'] = 0;
-
+$conf['addpage_createns'] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -4,3 +4,4 @@ $meta['addpage_showroot'] = array('onoff');
 $meta['addpage_hide']     = array('onoff');
 $meta['addpage_hideACL']  = array('onoff');
 $meta['addpage_autopage'] = array('onoff');
+$meta['addpage_createns'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,8 +4,9 @@
 /*
  * English language file
  */
-$lang['addpage_exclude']  = "Excluded namespaces (separated with ;)";
+$lang['addpage_exclude'] = "Excluded namespaces (separated with <code>;</code>)";
 $lang['addpage_showroot'] = "Show root namespace";
-$lang['addpage_hide']     = "When you use {{NEWPAGE>[ns]}} syntax: Hide namespace selection (unchecked: show only subnamespaces)";
-$lang['addpage_hideACL']  = "Hide {{NEWPAGE}} if user does not have rights to add pages (show message if unchecked)";
-$lang['addpage_autopage'] = "Don't show the input box, the preconfigured namespace is treated as a full page ID. (makes sense with date placeholders)";
+$lang['addpage_hide'] = "When using a default namespace (with <code>{{NEWPAGE>ns}}</code> syntax), hide the namespace selector (if unchecked, the selector will only contain subnamespaces)";
+$lang['addpage_hideACL']  = "Hide the <code>{{NEWPAGE}}</code> form if user does not have rights to add pages (if unchecked, a message is shown).";
+$lang['addpage_autopage'] = "Do not show the input box, the preconfigured namespace is treated as a full page ID (makes sense with date placeholders).";
+$lang['addpage_createns'] = "Allow the creation of subnamespaces. If unchecked, colons (<code>:</code>) in the page name will be replaced by underscore (<code>_</code>).";

--- a/script.js
+++ b/script.js
@@ -24,12 +24,19 @@ jQuery(function () {
 
             // Build the new page ID
             let page_id = $ns.val();
+            let page_title = $title.val();
+
+            // Prevent subnamespace creation
+            if (!$title.data('createns')) {
+                page_title = page_title.replaceAll(':', '_');
+            }
+
             if (page_id.indexOf(PLACEHOLDER) !== -1) {
                 // Process the placeholder
-                page_id = page_id.replaceAll(PLACEHOLDER, $title.val());
-            } else if ($title.val()) {
+                page_id = page_id.replaceAll(PLACEHOLDER, page_title);
+            } else if (page_title) {
                 // There is no placeholder, just append the user's input (if any)
-                page_id += ":" + $title.val();
+                page_id += ":" + page_title;
             }
 
             // Save the new page ID in the hidden form field

--- a/syntax.php
+++ b/syntax.php
@@ -88,6 +88,7 @@ class syntax_plugin_addnewpage extends SyntaxPlugin {
                 'hide' => $this->getConf('addpage_hide'),
                 'hideacl' => $this->getConf('addpage_hideACL'),
                 'autopage' => $this->getConf('addpage_autopage'),
+                'createns' => $this->getConf('addpage_createns'),
                 'label' => 'okbutton',
             )
         );
@@ -154,7 +155,10 @@ class syntax_plugin_addnewpage extends SyntaxPlugin {
                     . '" accept-charset="' . $lang['encoding'] . '">'
                 . $namespaceinput
                 . '<input class="edit" type="' . $input . '" name="title" size="20" maxlength="255" tabindex="2" placeholder="'
-                    . $this->getLang('name') . '"/>'
+                    . $this->getLang('name')
+                    // Use a data attribute to pass the createns option's state to JavaScript
+                    . '" data-createns="' . $this->options['createns'] 
+                    . '"/>'
                 . $newpagetemplateinput
                 . '<input type="hidden" name="newpagevars" value="' . $data['newpagevars'] . '"/>'
                 . '<input type="hidden" name="do" value="edit" />'


### PR DESCRIPTION
New 'createns' config option, enabled by default. If disabled, any `:` in the page name will be replaced by `_` when determining the page name.

Fixes #120